### PR TITLE
chore: update version of Terraform provider for SAP BTP

### DIFF
--- a/exercises/ex1/infra/provider.tf
+++ b/exercises/ex1/infra/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.16.1"
+      version = "~> 1.17.0"
     }
   }
 }

--- a/modules/sap-btp-default-apps-and-services/README.md
+++ b/modules/sap-btp-default-apps-and-services/README.md
@@ -7,13 +7,13 @@ This module encapsulates the default service instances and app subscriptions for
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12 |
-| <a name="requirement_btp"></a> [btp](#requirement\_btp) | >= 1.16.1 |
+| <a name="requirement_btp"></a> [btp](#requirement\_btp) | >= 1.17.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_btp"></a> [btp](#provider\_btp) | >= 1.16.1 |
+| <a name="provider_btp"></a> [btp](#provider\_btp) | >= 1.17.0 |
 
 ## Modules
 

--- a/modules/sap-btp-default-apps-and-services/versions.tf
+++ b/modules/sap-btp-default-apps-and-services/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = ">= 1.16.1"
+      version = ">= 1.17.0"
     }
   }
 }

--- a/modules/sap-btp-subaccount-setup/README.md
+++ b/modules/sap-btp-subaccount-setup/README.md
@@ -7,13 +7,13 @@ This module encapsulates the default setup for SAP BTP subaccounts. It distingui
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12 |
-| <a name="requirement_btp"></a> [btp](#requirement\_btp) | >= 1.16.1 |
+| <a name="requirement_btp"></a> [btp](#requirement\_btp) | >= 1.17.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_btp"></a> [btp](#provider\_btp) | >= 1.16.1 |
+| <a name="provider_btp"></a> [btp](#provider\_btp) | >= 1.17.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 

--- a/modules/sap-btp-subaccount-setup/versions.tf
+++ b/modules/sap-btp-subaccount-setup/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = ">= 1.16.1"
+      version = ">= 1.17.0"
     }
   }
 }

--- a/solutions/ex1/ex12/provider.tf
+++ b/solutions/ex1/ex12/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.16.1"
+      version = "~> 1.17.0"
     }
   }
 }

--- a/solutions/ex1/ex13/provider.tf
+++ b/solutions/ex1/ex13/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.16.1"
+      version = "~> 1.17.0"
     }
   }
 }

--- a/solutions/ex1/ex14/provider.tf
+++ b/solutions/ex1/ex14/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.16.1"
+      version = "~> 1.17.0"
     }
   }
 }


### PR DESCRIPTION
Update version of Terraform provider for SAP BTP to latest (1.17.0)
